### PR TITLE
create lock implementation

### DIFF
--- a/Lab03/src/kvsrv1/client.go
+++ b/Lab03/src/kvsrv1/client.go
@@ -1,6 +1,8 @@
 package kvsrv
 
 import (
+	"time"
+
 	"cpsc416-2025w1/kvsrv1/rpc"
 	kvtest "cpsc416-2025w1/kvtest1"
 	tester "cpsc416-2025w1/tester1"
@@ -41,6 +43,9 @@ func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 		if ok && reply.Err == rpc.ErrNoKey {
 			return "", 0, rpc.ErrNoKey
 		}
+
+		// Network failure, retry after a delay
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 
@@ -70,7 +75,9 @@ func (ck *Clerk) Put(key, value string, version rpc.Tversion) rpc.Err {
 		ok := ck.clnt.Call(ck.server, "KVServer.Put", &args, &reply)
 
 		if !ok {
+			// Network failure - retry after delay
 			firstAttempt = false
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 		

--- a/Lab03/src/kvsrv1/lock/lock.go
+++ b/Lab03/src/kvsrv1/lock/lock.go
@@ -10,8 +10,9 @@ type Lock struct {
 	// the specific Clerk type of ck but promises that ck supports
 	// Put and Get.  The tester passes the clerk in when calling
 	// MakeLock().
-	ck kvtest.IKVClerk
-	// You may add code here
+	ck       kvtest.IKVClerk
+	key      string // key to identify the lock
+	clientId string // unique identifier for this client
 }
 
 // The tester calls MakeLock() and passes in a k/v clerk; your code can
@@ -20,15 +21,50 @@ type Lock struct {
 // Use l as the key to store the "lock state" (you would have to decide
 // precisely what the lock state is).
 func MakeLock(ck kvtest.IKVClerk, l string) *Lock {
-	lk := &Lock{ck: ck}
-	// You may add code here
+	lk := &Lock{
+		ck:       ck,
+		key:      l,
+		clientId: kvtest.RandValue(8),
+	}
 	return lk
 }
 
 func (lk *Lock) Acquire() {
-	// Your code here
+	for {
+		value, version, err := lk.ck.Get(lk.key)
+
+		if err == rpc.ErrNoKey {
+			err = lk.ck.Put(lk.key, lk.clientId, 0)
+			if err == rpc.OK {
+				return
+			}
+			continue
+		}
+
+		if value == "" {
+			err = lk.ck.Put(lk.key, lk.clientId, version)
+			if err == rpc.OK {
+				return
+			}
+		}
+	}
 }
 
 func (lk *Lock) Release() {
-	// Your code here
+	for {
+		value, version, err := lk.ck.Get(lk.key)
+
+		if err == rpc.ErrNoKey {
+			return
+		}
+
+		if value == lk.clientId {
+			err = lk.ck.Put(lk.key, "", version)
+			if err == rpc.OK {
+				return
+			}
+		} else {
+			return
+		}
+	}
 }

--- a/Lab03/src/kvsrv1/lock/lock.go
+++ b/Lab03/src/kvsrv1/lock/lock.go
@@ -38,6 +38,13 @@ func (lk *Lock) Acquire() {
 			if err == rpc.OK {
 				return
 			}
+			// On ErrMaybe, we need to check if we got the lock
+			if err == rpc.ErrMaybe {
+				value, _, err := lk.ck.Get(lk.key)
+				if err == rpc.OK && value == lk.clientId {
+					return
+				}
+			}
 			continue
 		}
 
@@ -45,6 +52,13 @@ func (lk *Lock) Acquire() {
 			err = lk.ck.Put(lk.key, lk.clientId, version)
 			if err == rpc.OK {
 				return
+			}
+			// On ErrMaybe, we need to check if we got the lock
+			if err == rpc.ErrMaybe {
+				value, _, err := lk.ck.Get(lk.key)
+				if err == rpc.OK && value == lk.clientId {
+					return
+				}
 			}
 		}
 	}
@@ -62,6 +76,16 @@ func (lk *Lock) Release() {
 			err = lk.ck.Put(lk.key, "", version)
 			if err == rpc.OK {
 				return
+			}
+			// On ErrMaybe, we need to check if we released the lock
+			if err == rpc.ErrMaybe {
+				value, _, err := lk.ck.Get(lk.key)
+				if err == rpc.OK && value == "" {
+					return
+				}
+				if err == rpc.ErrNoKey {
+					return
+				}
 			}
 		} else {
 			return


### PR DESCRIPTION
## Description
Implementing the release and acquire for the lock. The implementation details are as follows:

### Aquire
1. We try to get the lock using `Get`. 
2. If we the lock doesn't exist, create it.
3. If the lock is free (ie. the value or in this case, the `clientId` is empty), acquire it by setting our `clientId` using `Put`.
4. If we don't pass the above statements, the lock isn't free and we repeat the `for` loop. 

### Release
1. We try to get the lock using `Get`.
2. If the lock doesn't exist continue.
3. If the `clientId` is ours, then we release the lock, setting the value to empty. 
4. If the above checks don't pass, we repeat until lock is released. 